### PR TITLE
Pipeline Fingerprint for threshold keying

### DIFF
--- a/src/pyagentshield/core/shield.py
+++ b/src/pyagentshield/core/shield.py
@@ -330,8 +330,17 @@ class AgentShield:
         threshold = calibrator.calibrate(corpus)
 
         if save:
+            # Use ThresholdManager._build_fingerprint so the key matches
+            # what runtime lookup produces (uses actual cleaner.method,
+            # not config string — important for hybrid cleaners).
+            fp = self.threshold_manager._build_fingerprint(
+                model_name=self.embedding_provider.model_name,
+                embedding_provider=self.embedding_provider,
+                text_cleaner=self.text_cleaner,
+            )
+            key = fp or self.embedding_provider.model_name
             self.threshold_manager.set_threshold(
-                self.embedding_provider.model_name,
+                key,
                 threshold,
                 save=True,
             )

--- a/src/pyagentshield/threshold/fingerprint.py
+++ b/src/pyagentshield/threshold/fingerprint.py
@@ -1,0 +1,145 @@
+"""Pipeline fingerprint for threshold keying.
+
+Thresholds depend on the full pipeline configuration — not just the embedding
+model.  The same model paired with a different cleaner produces a different
+drift distribution and therefore needs a different threshold.
+
+Fingerprint format:
+    {provider_host}::{embedding_model}::{cleaning_method}[::{cleaning_model}]
+
+Each segment is URL-encoded before joining, so the literal ``"::"``
+delimiter is safe even when values contain colons (e.g. IPv6 hosts).
+
+Examples:
+    local::all-MiniLM-L6-v2::heuristic
+    openai.com::text-embedding-3-small::llm::gpt-4o-mini
+    openrouter.ai::meta-llama/llama-3.1-8b::llm::gpt-4o-mini
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from urllib.parse import quote, unquote, urlparse
+
+
+def extract_host(base_url: Optional[str], provider: str) -> str:
+    """Extract host identifier from a base_url or provider name.
+
+    Includes the port when present, so ``localhost:11434`` and
+    ``localhost:8000`` produce distinct identifiers (important when
+    Ollama and vLLM run on the same machine).
+
+    Known canonical endpoints (e.g. ``https://api.openai.com/v1``) are
+    normalised to the same value as ``base_url=None`` for that provider,
+    so explicit-default and omitted-default produce the same key.
+
+    Args:
+        base_url: Optional API base URL (e.g. ``https://openrouter.ai/api/v1``)
+        provider: Provider type (``"local"``, ``"openai"``, ``"mlx"``, …)
+
+    Returns:
+        Host string used in fingerprint (e.g. ``"openrouter.ai"``,
+        ``"localhost:11434"``, ``"local"``)
+    """
+    # Default hosts per provider
+    defaults: Dict[str, str] = {
+        "local": "local",
+        "openai": "openai.com",
+        "mlx": "local",
+    }
+
+    # Canonical hostnames that should map back to the provider default.
+    # Prevents cache fragmentation when users explicitly set the default URL.
+    _CANONICAL_HOSTS: Dict[str, str] = {
+        "api.openai.com": "openai.com",
+    }
+
+    # Default ports per scheme — these are invisible to the server and
+    # should not appear in identity keys.
+    _DEFAULT_PORTS = {"https": 443, "http": 80}
+
+    if base_url:
+        parsed = urlparse(base_url)
+        host = parsed.hostname
+        if host:
+            port = parsed.port
+            scheme_default = _DEFAULT_PORTS.get(parsed.scheme)
+            # Strip default port for the scheme (e.g. :443 for https)
+            if port is not None and port == scheme_default:
+                port = None
+
+            # Normalise canonical endpoints (after port stripping)
+            canonical = _CANONICAL_HOSTS.get(host)
+            if canonical is not None and port is None:
+                return canonical
+
+            if port is not None:
+                return f"{host}:{port}"
+            return host
+
+    return defaults.get(provider, provider)
+
+
+def create_pipeline_fingerprint(
+    provider_host: str,
+    embedding_model: str,
+    cleaning_method: str,
+    cleaning_model: Optional[str] = None,
+    cleaning_host: Optional[str] = None,
+) -> str:
+    """Build a fingerprint string for a specific pipeline configuration.
+
+    Args:
+        provider_host: Host identifier (from :func:`extract_host`)
+        embedding_model: Embedding model name
+        cleaning_method: Cleaning method name (``"heuristic"``, ``"llm"``, …)
+        cleaning_model: Optional model used by the cleaner (e.g. ``"gpt-4o-mini"``)
+        cleaning_host: Optional host where the cleaner runs. Included when
+            provided by the caller. Most current manager flows encode cleaner
+            backend identity directly in ``cleaning_model`` for LLM/finetuned.
+
+    Returns:
+        Fingerprint string such as ``"local::all-MiniLM-L6-v2::heuristic"``
+    """
+    # Escape each part so delimiter collisions are impossible (notably IPv6
+    # hosts like ::1) while keeping common model/host strings readable.
+    def _escape(value: str) -> str:
+        return quote(value, safe="-._~/+@()[]")
+
+    parts = [_escape(provider_host), _escape(embedding_model), _escape(cleaning_method)]
+    if cleaning_model:
+        parts.append(_escape(cleaning_model))
+    if cleaning_host:
+        parts.append(_escape(cleaning_host))
+    return "::".join(parts)
+
+
+def parse_pipeline_fingerprint(fingerprint: str) -> Dict[str, Optional[str]]:
+    """Parse a fingerprint string back into its components.
+
+    Args:
+        fingerprint: Fingerprint produced by :func:`create_pipeline_fingerprint`
+
+    Returns:
+        Dictionary with keys ``provider_host``, ``embedding_model``,
+        ``cleaning_method``, and ``cleaning_model`` (may be ``None``).
+
+    Raises:
+        ValueError: If the fingerprint has fewer than 3 parts.
+    """
+    parts = fingerprint.split("::")
+    if len(parts) < 3:
+        raise ValueError(
+            f"Invalid fingerprint (expected at least 3 '::'-separated parts): {fingerprint!r}"
+        )
+
+    def _unescape(value: str) -> str:
+        return unquote(value)
+
+    return {
+        "provider_host": _unescape(parts[0]),
+        "embedding_model": _unescape(parts[1]),
+        "cleaning_method": _unescape(parts[2]),
+        "cleaning_model": _unescape(parts[3]) if len(parts) > 3 else None,
+        "cleaning_host": _unescape(parts[4]) if len(parts) > 4 else None,
+    }

--- a/src/pyagentshield/threshold/manager.py
+++ b/src/pyagentshield/threshold/manager.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
+from pyagentshield.threshold.fingerprint import (
+    create_pipeline_fingerprint,
+    extract_host,
+)
 from pyagentshield.threshold.registry import ThresholdRegistry
 
 if TYPE_CHECKING:
@@ -15,6 +21,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Cache format version — triggers migration from older formats.
+_CACHE_VERSION = 2
+
 
 class ThresholdManager:
     """
@@ -22,9 +31,10 @@ class ThresholdManager:
 
     Threshold resolution order:
     1. Explicit default (if set in config)
-    2. Custom (user-calibrated, stored in cache)
-    3. Pre-calibrated registry
-    4. Auto-calibrate on first use
+    2. Custom (user-calibrated, stored in cache) — fingerprint key first, then model-name key
+    3. Finetuned calibration.json in model directory
+    4. Pre-calibrated registry (model-name only — registry was calibrated with heuristic cleaner)
+    5. Auto-calibrate on first use
 
     Usage:
         manager = ThresholdManager(cache_dir=Path.home() / ".agentshield")
@@ -48,45 +58,196 @@ class ThresholdManager:
 
         self.default_threshold = default_threshold
         self._custom_thresholds: Dict[str, float] = {}
+        self._lock = threading.Lock()
 
-        # Load cached thresholds
+        # Load cached thresholds (migrating if needed)
         self._load_cached_thresholds()
 
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
     def _load_cached_thresholds(self) -> None:
-        """Load all cached thresholds from disk."""
+        """Load all cached thresholds from disk, migrating old format if needed."""
         cache_file = self.cache_dir / "custom_thresholds.json"
         if cache_file.exists():
             try:
                 with open(cache_file) as f:
-                    self._custom_thresholds = json.load(f)
+                    data = json.load(f)
+                if data.get("_version") != _CACHE_VERSION:
+                    data = self._migrate_legacy_cache(data, cache_file)
+                # Strip internal keys
+                self._custom_thresholds = {
+                    k: v for k, v in data.items() if not k.startswith("_")
+                }
                 logger.debug(f"Loaded {len(self._custom_thresholds)} cached thresholds")
             except Exception as e:
                 logger.warning(f"Failed to load cached thresholds: {e}")
 
+    def _migrate_legacy_cache(
+        self, data: Dict, cache_file: Path
+    ) -> Dict:
+        """Migrate v1 cache to v2 by adding a version marker.
+
+        Old format::
+
+            {"all-MiniLM-L6-v2": 0.23}
+
+        New format — keeps old model-name keys intact so they remain
+        reachable via the legacy model-name fallback path (step 2b) for
+        backward-compatible calls (no cleaner provided) and heuristic
+        pipelines. We cannot know which provider/cleaner was used when the
+        entry was created, so renaming keys would risk making them
+        unreachable at runtime::
+
+            {"_version": 2, "all-MiniLM-L6-v2": 0.23}
+
+        A ``.backup`` copy of the original file is created before overwriting.
+        """
+        backup = cache_file.with_suffix(".json.backup")
+        shutil.copy2(cache_file, backup)
+        logger.info(f"Backed up legacy threshold cache to {backup}")
+
+        migrated: Dict = {"_version": _CACHE_VERSION}
+        for key, value in data.items():
+            if key.startswith("_"):
+                continue
+            # Keep original model-name key as-is — the legacy model-name
+            # fallback in get_threshold (step 2b) can still use it for
+            # backward-compatible calls and heuristic pipelines.
+            migrated[key] = value
+
+        self._save_data(migrated)
+        return migrated
+
     def _save_cached_thresholds(self) -> None:
-        """Save custom thresholds to disk."""
+        """Save custom thresholds to disk (thread-safe)."""
+        data: Dict = {"_version": _CACHE_VERSION}
+        data.update(self._custom_thresholds)
+        self._save_data(data)
+
+    def _save_data(self, data: Dict) -> None:
+        """Atomic-ish write of threshold data to disk."""
         cache_file = self.cache_dir / "custom_thresholds.json"
+        tmp_file = cache_file.with_suffix(".json.tmp")
         try:
-            with open(cache_file, "w") as f:
-                json.dump(self._custom_thresholds, f, indent=2)
+            with self._lock:
+                with open(tmp_file, "w") as f:
+                    json.dump(data, f, indent=2)
+                tmp_file.replace(cache_file)
         except Exception as e:
             logger.warning(f"Failed to save cached thresholds: {e}")
+            if tmp_file.exists():
+                tmp_file.unlink()
+
+    # ------------------------------------------------------------------
+    # Fingerprint helpers
+    # ------------------------------------------------------------------
+
+    def _build_fingerprint(
+        self,
+        model_name: str,
+        embedding_provider: Optional[EmbeddingProvider] = None,
+        text_cleaner: Optional[TextCleaner] = None,
+        provider_host: Optional[str] = None,
+    ) -> Optional[str]:
+        """Build a fingerprint if enough information is available."""
+        if text_cleaner is None:
+            return None
+
+        host = provider_host
+        if host is None:
+            base_url = getattr(embedding_provider, "_base_url", None)
+            provider_type = getattr(embedding_provider, "_provider_type", None)
+            if provider_type is None:
+                # Infer from class name
+                cls_name = type(embedding_provider).__name__.lower() if embedding_provider else ""
+                if "openai" in cls_name:
+                    provider_type = "openai"
+                elif "mlx" in cls_name:
+                    provider_type = "mlx"
+                elif "local" in cls_name:
+                    provider_type = "local"
+                elif cls_name:
+                    # Preserve provider identity for unknown provider classes
+                    # instead of collapsing to "local", which can cause key collisions.
+                    provider_type = f"class:{cls_name}"
+                    logger.debug(
+                        "Unknown embedding provider type for %s; using class-derived host key %s",
+                        type(embedding_provider).__name__,
+                        provider_type,
+                    )
+                else:
+                    provider_type = "local"
+            host = extract_host(base_url, provider_type)
+
+        cleaning_model: Optional[str] = None
+        cleaning_host: Optional[str] = None
+        method = text_cleaner.method
+
+        # Build cleaner identities for methods that materially change drift
+        # distributions (LLM backend/model and finetuned model source).
+        cleaner_identities = []
+
+        def _append_cleaner_identity(cleaner: TextCleaner) -> None:
+            c_method = cleaner.method
+            if c_method == "llm":
+                default_host = extract_host(None, "openai")
+                m = getattr(cleaner, "_model", None) or "unknown"
+                bu = getattr(cleaner, "_base_url", None)
+                h = extract_host(bu, "openai") if bu else default_host
+                cleaner_identities.append(f"{m}@{h}")
+            elif c_method == "finetuned":
+                model_path = getattr(cleaner, "_model_path", None)
+                model_id = getattr(cleaner, "_model_id", None)
+                source = str(model_path) if model_path else model_id or "unknown"
+                cleaner_identities.append(f"finetuned:{source}")
+
+        if method in {"llm", "finetuned"}:
+            _append_cleaner_identity(text_cleaner)
+        else:
+            nested = getattr(text_cleaner, "cleaners", None)
+            if nested:
+                for cleaner in nested:
+                    _append_cleaner_identity(cleaner)
+
+        if cleaner_identities:
+            cleaning_model = "+".join(cleaner_identities)
+
+        return create_pipeline_fingerprint(
+            provider_host=host,
+            embedding_model=model_name,
+            cleaning_method=method,
+            cleaning_model=cleaning_model,
+            cleaning_host=cleaning_host,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def get_threshold(
         self,
         model_name: str,
         embedding_provider: Optional[EmbeddingProvider] = None,
         text_cleaner: Optional[TextCleaner] = None,
+        provider_host: Optional[str] = None,
         auto_calibrate: bool = True,
         model_path: Optional[str] = None,
     ) -> float:
         """
-        Get threshold for a model.
+        Get threshold for a pipeline configuration.
+
+        When ``text_cleaner`` (and optionally ``provider_host``) are provided,
+        a fingerprint key is used for lookup/storage.  When only ``model_name``
+        is given, the legacy model-name-only path is used for backward
+        compatibility.
 
         Args:
             model_name: Name of the embedding model
             embedding_provider: Provider for auto-calibration (if needed)
-            text_cleaner: Cleaner for auto-calibration (if needed)
+            text_cleaner: Cleaner for auto-calibration and fingerprinting
+            provider_host: Explicit provider host for fingerprinting
             auto_calibrate: Whether to auto-calibrate if no threshold found
             model_path: Local path to finetuned model (for loading calibration.json)
 
@@ -100,19 +261,36 @@ class ThresholdManager:
         if self.default_threshold is not None:
             return self.default_threshold
 
-        # 2. Check custom (user-calibrated)
+        # Build fingerprint if we can
+        fingerprint = self._build_fingerprint(
+            model_name, embedding_provider, text_cleaner, provider_host
+        )
+
+        # 2. Check custom cache — fingerprint key first
+        if fingerprint and fingerprint in self._custom_thresholds:
+            return self._custom_thresholds[fingerprint]
+
+        # 2b. Legacy fallback: model-name-only custom cache key.
+        # Restricted to backward-compatible calls / heuristic-equivalent
+        # pipelines so old thresholds don't leak across cleaner types.
         if model_name in self._custom_thresholds:
-            return self._custom_thresholds[model_name]
+            if self._legacy_custom_fallback_allowed(text_cleaner):
+                return self._custom_thresholds[model_name]
+            logger.info(
+                "Ignoring legacy model-name custom threshold for non-heuristic pipeline: %s",
+                model_name,
+            )
 
         # 3. Check for calibration.json in finetuned model directory
         finetuned_threshold = self._load_finetuned_calibration(model_name, model_path)
         if finetuned_threshold is not None:
             return finetuned_threshold
 
-        # 4. Check registry
-        registry_threshold = ThresholdRegistry.get(model_name)
-        if registry_threshold is not None:
-            return registry_threshold
+        # 4. Check registry (heuristic pipelines only — registry is heuristic-calibrated)
+        if self._registry_fallback_allowed(text_cleaner):
+            registry_threshold = ThresholdRegistry.get(model_name)
+            if registry_threshold is not None:
+                return registry_threshold
 
         # 5. Auto-calibrate
         if auto_calibrate:
@@ -124,13 +302,37 @@ class ThresholdManager:
                 return 0.20
 
             logger.info(f"Auto-calibrating threshold for {model_name}...")
-            threshold = self._auto_calibrate(model_name, embedding_provider, text_cleaner)
+            threshold = self._auto_calibrate(
+                model_name, embedding_provider, text_cleaner, provider_host
+            )
             return threshold
 
         raise ValueError(
             f"No threshold found for model '{model_name}'. "
             f"Run calibration with: agentshield calibrate --model {model_name}"
         )
+
+    @staticmethod
+    def _registry_fallback_allowed(text_cleaner: Optional[TextCleaner]) -> bool:
+        """Allow model-name registry fallback only for heuristic-equivalent pipelines."""
+        if text_cleaner is None:
+            return True
+
+        method = text_cleaner.method
+        if method == "heuristic":
+            return True
+
+        nested = getattr(text_cleaner, "cleaners", None)
+        if not nested:
+            return False
+
+        # Hybrid cleaner is heuristic-equivalent only if all nested cleaners are heuristic.
+        return all(getattr(cleaner, "method", None) == "heuristic" for cleaner in nested)
+
+    @staticmethod
+    def _legacy_custom_fallback_allowed(text_cleaner: Optional[TextCleaner]) -> bool:
+        """Allow legacy model-name custom-key fallback under the same safety rules as registry fallback."""
+        return ThresholdManager._registry_fallback_allowed(text_cleaner)
 
     def _load_finetuned_calibration(
         self,
@@ -201,6 +403,7 @@ class ThresholdManager:
         model_name: str,
         embedding_provider: EmbeddingProvider,
         text_cleaner: TextCleaner,
+        provider_host: Optional[str] = None,
     ) -> float:
         """Auto-calibrate threshold for a model."""
         from pyagentshield.threshold.calibrator import ThresholdCalibrator
@@ -212,8 +415,12 @@ class ThresholdManager:
 
         threshold = calibrator.calibrate()
 
-        # Save to cache
-        self.set_threshold(model_name, threshold, save=True)
+        # Save with fingerprint key
+        fingerprint = self._build_fingerprint(
+            model_name, embedding_provider, text_cleaner, provider_host
+        )
+        key = fingerprint or model_name
+        self.set_threshold(key, threshold, save=True)
 
         return threshold
 
@@ -224,10 +431,13 @@ class ThresholdManager:
         save: bool = True,
     ) -> None:
         """
-        Set a custom threshold for a model.
+        Set a custom threshold.
+
+        The ``model_name`` argument can be either a plain model name
+        (legacy) or a full fingerprint string.
 
         Args:
-            model_name: Name of the embedding model
+            model_name: Model name or pipeline fingerprint
             threshold: Threshold value
             save: Whether to persist to disk
         """
@@ -238,13 +448,37 @@ class ThresholdManager:
 
         logger.info(f"Set threshold for {model_name}: {threshold:.6f}")
 
-    def has_threshold(self, model_name: str) -> bool:
-        """Check if a threshold exists for a model."""
+    def has_threshold(
+        self,
+        model_name: str,
+        embedding_provider: Optional[EmbeddingProvider] = None,
+        text_cleaner: Optional[TextCleaner] = None,
+        provider_host: Optional[str] = None,
+        model_path: Optional[str] = None,
+    ) -> bool:
+        """Check if a threshold exists for a model/pipeline without auto-calibrating."""
         if self.default_threshold is not None:
             return True
-        if model_name in self._custom_thresholds:
+
+        fingerprint = self._build_fingerprint(
+            model_name, embedding_provider, text_cleaner, provider_host
+        )
+        if fingerprint and fingerprint in self._custom_thresholds:
             return True
-        return ThresholdRegistry.has(model_name)
+
+        if (
+            model_name in self._custom_thresholds
+            and self._legacy_custom_fallback_allowed(text_cleaner)
+        ):
+            return True
+
+        if self._load_finetuned_calibration(model_name, model_path) is not None:
+            return True
+
+        if self._registry_fallback_allowed(text_cleaner):
+            return ThresholdRegistry.has(model_name)
+
+        return False
 
     def list_thresholds(self) -> Dict[str, float]:
         """List all available thresholds."""

--- a/src/pyagentshield/threshold/registry.py
+++ b/src/pyagentshield/threshold/registry.py
@@ -52,12 +52,15 @@ class ThresholdRegistry:
     }
 
     @classmethod
-    def get(cls, model_name: str) -> Optional[float]:
+    def get(cls, model_name: str, cleaning_method: Optional[str] = None) -> Optional[float]:
         """
         Get pre-calibrated threshold for a model.
 
         Args:
             model_name: Name of the embedding model
+            cleaning_method: Optional cleaning method for future per-pipeline
+                registry entries. Currently ignored — all registry thresholds
+                were calibrated with the heuristic cleaner.
 
         Returns:
             Threshold value or None if not found

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ class MockEmbeddingProvider:
     def __init__(self, model_name: str = "mock-model", dimensions: int = 384):
         self._model_name = model_name
         self._dimensions = dimensions
+        self._provider_type = "local"
         self._overrides: Dict[str, NDArray[np.floating]] = {}
 
     @property

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,192 @@
+"""Tests for pipeline fingerprint."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyagentshield.threshold.fingerprint import (
+    create_pipeline_fingerprint,
+    extract_host,
+    parse_pipeline_fingerprint,
+)
+
+
+class TestExtractHost:
+    def test_from_base_url(self):
+        assert extract_host("https://openrouter.ai/api/v1", "openai") == "openrouter.ai"
+
+    def test_from_base_url_with_port(self):
+        assert extract_host("http://localhost:11434/v1", "openai") == "localhost:11434"
+
+    def test_default_openai(self):
+        assert extract_host(None, "openai") == "openai.com"
+
+    def test_default_local(self):
+        assert extract_host(None, "local") == "local"
+
+    def test_default_mlx(self):
+        assert extract_host(None, "mlx") == "local"
+
+    def test_unknown_provider_uses_name(self):
+        assert extract_host(None, "custom") == "custom"
+
+    def test_empty_url_falls_back(self):
+        assert extract_host("", "openai") == "openai.com"
+
+    def test_ipv6_with_port(self):
+        assert extract_host("http://[::1]:11434/v1", "openai") == "::1:11434"
+
+
+class TestCreatePipelineFingerprint:
+    def test_heuristic_local(self):
+        fp = create_pipeline_fingerprint("local", "all-MiniLM-L6-v2", "heuristic")
+        assert fp == "local::all-MiniLM-L6-v2::heuristic"
+
+    def test_llm_with_model(self):
+        fp = create_pipeline_fingerprint(
+            "openai.com", "text-embedding-3-small", "llm", "gpt-4o-mini"
+        )
+        assert fp == "openai.com::text-embedding-3-small::llm::gpt-4o-mini"
+
+    def test_openrouter(self):
+        fp = create_pipeline_fingerprint(
+            "openrouter.ai", "meta-llama/llama-3.1-8b", "llm", "gpt-4o-mini"
+        )
+        assert fp == "openrouter.ai::meta-llama/llama-3.1-8b::llm::gpt-4o-mini"
+
+    def test_finetuned(self):
+        fp = create_pipeline_fingerprint("local", "all-MiniLM-L6-v2", "finetuned")
+        assert fp == "local::all-MiniLM-L6-v2::finetuned"
+
+    def test_same_model_different_hosts_differ(self):
+        fp1 = create_pipeline_fingerprint(
+            "openai.com", "text-embedding-3-small", "heuristic"
+        )
+        fp2 = create_pipeline_fingerprint(
+            "openrouter.ai", "text-embedding-3-small", "heuristic"
+        )
+        assert fp1 != fp2
+
+    def test_same_model_different_cleaners_differ(self):
+        fp1 = create_pipeline_fingerprint("local", "all-MiniLM-L6-v2", "heuristic")
+        fp2 = create_pipeline_fingerprint("local", "all-MiniLM-L6-v2", "llm", "gpt-4o-mini")
+        assert fp1 != fp2
+
+
+class TestParsePipelineFingerprint:
+    def test_round_trip_without_cleaning_model(self):
+        fp = create_pipeline_fingerprint("local", "all-MiniLM-L6-v2", "heuristic")
+        parsed = parse_pipeline_fingerprint(fp)
+        assert parsed == {
+            "provider_host": "local",
+            "embedding_model": "all-MiniLM-L6-v2",
+            "cleaning_method": "heuristic",
+            "cleaning_model": None,
+            "cleaning_host": None,
+        }
+
+    def test_round_trip_with_cleaning_model(self):
+        fp = create_pipeline_fingerprint(
+            "openai.com", "text-embedding-3-small", "llm", "gpt-4o-mini"
+        )
+        parsed = parse_pipeline_fingerprint(fp)
+        assert parsed == {
+            "provider_host": "openai.com",
+            "embedding_model": "text-embedding-3-small",
+            "cleaning_method": "llm",
+            "cleaning_model": "gpt-4o-mini",
+            "cleaning_host": None,
+        }
+
+    def test_invalid_fingerprint_raises(self):
+        with pytest.raises(ValueError, match="Invalid fingerprint"):
+            parse_pipeline_fingerprint("only::two")
+
+    def test_round_trip_with_cleaning_host(self):
+        fp = create_pipeline_fingerprint(
+            "local", "all-MiniLM-L6-v2", "llm", "gpt-4o-mini", "openrouter.ai"
+        )
+        parsed = parse_pipeline_fingerprint(fp)
+        assert parsed == {
+            "provider_host": "local",
+            "embedding_model": "all-MiniLM-L6-v2",
+            "cleaning_method": "llm",
+            "cleaning_model": "gpt-4o-mini",
+            "cleaning_host": "openrouter.ai",
+        }
+
+    def test_round_trip_ipv6_host(self):
+        fp = create_pipeline_fingerprint("::1:11434", "custom-model", "heuristic")
+        parsed = parse_pipeline_fingerprint(fp)
+        assert parsed == {
+            "provider_host": "::1:11434",
+            "embedding_model": "custom-model",
+            "cleaning_method": "heuristic",
+            "cleaning_model": None,
+            "cleaning_host": None,
+        }
+
+    def test_round_trip_literal_percent_sequence(self):
+        fp = create_pipeline_fingerprint("local", "abc%3A%3Adef", "heuristic")
+        parsed = parse_pipeline_fingerprint(fp)
+        assert parsed == {
+            "provider_host": "local",
+            "embedding_model": "abc%3A%3Adef",
+            "cleaning_method": "heuristic",
+            "cleaning_model": None,
+            "cleaning_host": None,
+        }
+
+
+class TestCollisionPrevention:
+    """Verify distinct endpoints produce distinct identifiers."""
+
+    def test_different_ports_different_hosts(self):
+        """localhost:11434 (Ollama) vs localhost:8000 (vLLM) must differ."""
+        h1 = extract_host("http://localhost:11434/v1", "openai")
+        h2 = extract_host("http://localhost:8000/v1", "openai")
+        assert h1 != h2
+        assert h1 == "localhost:11434"
+        assert h2 == "localhost:8000"
+
+    def test_standard_port_omitted_for_https(self):
+        """https://openai.com (no explicit port) gives just hostname."""
+        h = extract_host("https://openai.com/v1", "openai")
+        assert h == "openai.com"
+
+    def test_explicit_443_stripped_for_https(self):
+        """https://api.openai.com:443 should normalize to openai.com."""
+        h = extract_host("https://api.openai.com:443/v1", "openai")
+        assert h == "openai.com"
+
+    def test_explicit_80_stripped_for_http(self):
+        """http://example.com:80 should strip the port."""
+        h = extract_host("http://example.com:80/v1", "openai")
+        assert h == "example.com"
+
+    def test_non_default_port_on_canonical_host_kept(self):
+        """api.openai.com:8080 is non-standard, should not normalize."""
+        h = extract_host("https://api.openai.com:8080/v1", "openai")
+        assert h == "api.openai.com:8080"
+
+    def test_same_model_different_ports_different_fingerprints(self):
+        fp1 = create_pipeline_fingerprint("localhost:11434", "nomic-embed-text", "heuristic")
+        fp2 = create_pipeline_fingerprint("localhost:8000", "nomic-embed-text", "heuristic")
+        assert fp1 != fp2
+
+    def test_same_llm_model_different_cleaner_hosts(self):
+        """gpt-4o-mini via OpenAI vs OpenRouter = different fingerprints."""
+        fp1 = create_pipeline_fingerprint(
+            "local", "all-MiniLM-L6-v2", "llm", "gpt-4o-mini"
+        )
+        fp2 = create_pipeline_fingerprint(
+            "local", "all-MiniLM-L6-v2", "llm", "gpt-4o-mini", "openrouter.ai"
+        )
+        assert fp1 != fp2
+
+    def test_cleaner_host_none_when_default(self):
+        """No cleaning_host = no extra segment in fingerprint."""
+        fp = create_pipeline_fingerprint(
+            "local", "all-MiniLM-L6-v2", "llm", "gpt-4o-mini"
+        )
+        assert fp.count("::") == 3  # 4 parts, 3 separators


### PR DESCRIPTION
## Summary
Implement pipeline-aware threshold identity and resolution so thresholds are keyed by full pipeline fingerprint instead of embedding model name alone.

Closes #5.

## Problem
Thresholds were previously keyed by model name only. That conflates distinct pipelines and can reuse incorrect thresholds across:
- different cleaner methods
- same cleaner model on different backends/hosts
- hybrid cleaners with different nested model/host composition

This also caused calibration-save vs runtime-lookup key mismatch in hybrid flows.

## What changed
### 1) Fingerprint utility introduced
- Added `src/pyagentshield/threshold/fingerprint.py`.
- Added host extraction + normalization logic:
  - preserves host+port (`localhost:11434` vs `localhost:8000`)
  - strips default ports (`:443`, `:80`)
  - canonicalizes default OpenAI endpoint (`api.openai.com` => `openai.com`)
- Added robust fingerprint build/parse with URL-encoded segments (IPv6-safe and lossless parsing).

### 2) Threshold manager now resolves by pipeline identity
- `ThresholdManager` now builds fingerprint keys from:
  - embedding provider host identity
  - embedding model
  - cleaner method
  - cleaner identity for LLM (`model@host`) and finetuned (`finetuned:<model_id_or_path>`)
- Supports nested Hybrid cleaner identity extraction (ordered and composition-aware).
- Resolution order now:
  1. explicit default
  2. custom fingerprint key
  3. legacy model-name custom key (restricted)
  4. finetuned `calibration.json`
  5. registry (heuristic-equivalent only)
  6. auto-calibration

### 3) Legacy migration + safer fallback policy
- Added cache versioning/migration with backup:
  - v1 -> v2 migration with `_version` marker
  - backup file `custom_thresholds.json.backup`
- Legacy model-name thresholds are preserved for backward compatibility but not applied to non-heuristic pipelines.
- Added explicit log when legacy model-name custom threshold is skipped due to pipeline policy.

### 4) Calibration-save and API consistency updates
- `AgentShield.calibrate()` now saves thresholds using the same fingerprint path used by runtime lookup.
- `has_threshold(...)` now supports pipeline-aware arguments and aligns with non-autocalibrating `get_threshold(...)` behavior.

## Why this matters
Prevents threshold cross-talk between incompatible pipelines and ensures calibration/lookup consistency while still preserving legacy compatibility where safe.

## Validation
- Added `tests/test_fingerprint.py`.
- Expanded `tests/test_threshold.py` and `tests/conftest.py`.
- Focused test run:
  - `PYTHONPATH=src python3 -m pytest -q tests/test_threshold.py tests/test_fingerprint.py`
  - Result: passing.

## Changed files
- `src/pyagentshield/threshold/fingerprint.py` (new)
- `src/pyagentshield/threshold/manager.py`
- `src/pyagentshield/threshold/registry.py`
- `src/pyagentshield/core/shield.py`
- `tests/test_fingerprint.py` (new)
- `tests/test_threshold.py`
- `tests/conftest.py`