### PR TITLE
Multi model support

### DIFF
--- a/src/pyagentshield/cleaning/hybrid.py
+++ b/src/pyagentshield/cleaning/hybrid.py
@@ -342,11 +342,22 @@ def create_hybrid_cleaner(
 
             llm_kwargs = {
                 k: v for k, v in kwargs.items()
-                if k in ["model", "api_key", "temperature"]
+                if k in [
+                    "model", "api_key", "temperature",
+                    "base_url", "default_headers",
+                ]
             }
             # Rename 'model' to avoid conflict with finetuned
             if "llm_model" in kwargs:
                 llm_kwargs["model"] = kwargs["llm_model"]
+            # Allow llm-prefixed overrides for when both embed and clean
+            # base_urls differ
+            if "llm_base_url" in kwargs:
+                llm_kwargs["base_url"] = kwargs["llm_base_url"]
+            if "llm_api_key" in kwargs:
+                llm_kwargs["api_key"] = kwargs["llm_api_key"]
+            if "llm_default_headers" in kwargs:
+                llm_kwargs["default_headers"] = kwargs["llm_default_headers"]
             cleaners.append(LLMCleaner(**llm_kwargs))
 
         else:

--- a/src/pyagentshield/cleaning/llm.py
+++ b/src/pyagentshield/cleaning/llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pyagentshield.core.exceptions import CleaningError
 
@@ -49,6 +49,8 @@ Return ONLY the cleaned text with no explanation or commentary. If the entire te
         model: str = "gpt-3.5-turbo",
         api_key: Optional[str] = None,
         temperature: float = 0.0,
+        base_url: Optional[str] = None,
+        default_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initialize the LLM cleaner.
@@ -57,11 +59,15 @@ Return ONLY the cleaned text with no explanation or commentary. If the entire te
             model: OpenAI model to use
             api_key: OpenAI API key (uses OPENAI_API_KEY env var if not provided)
             temperature: Temperature for LLM (0.0 for deterministic)
+            base_url: Custom API base URL for OpenAI-compatible endpoints
+            default_headers: Extra HTTP headers sent with every request
         """
         self._method = "llm"
         self._model = model
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self._temperature = temperature
+        self._base_url = base_url
+        self._default_headers = default_headers
 
         if not self._api_key:
             raise CleaningError(
@@ -83,7 +89,12 @@ Return ONLY the cleaned text with no explanation or commentary. If the entire te
                     "Install with: pip install pyagentshield[openai]"
                 ) from e
 
-            self._client = OpenAI(api_key=self._api_key)
+            kwargs: Dict[str, Any] = {"api_key": self._api_key}
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            if self._default_headers:
+                kwargs["default_headers"] = self._default_headers
+            self._client = OpenAI(**kwargs)
 
         return self._client
 

--- a/src/pyagentshield/core/config.py
+++ b/src/pyagentshield/core/config.py
@@ -20,6 +20,11 @@ class EmbeddingConfig(BaseModel):
     # OpenAI-specific settings
     openai_model: str = "text-embedding-3-small"
 
+    # OpenAI-compatible endpoint overrides
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    default_headers: Optional[Dict[str, str]] = None
+
     # MLX-specific settings (Apple Silicon)
     mlx_cache_dir: Optional[str] = None  # Cache for converted MLX models
     mlx_convert_from_hf: bool = True  # Auto-convert from HuggingFace
@@ -78,6 +83,11 @@ class CleaningConfig(BaseModel):
 
     # LLM cleaner settings (OpenAI API)
     llm_model: str = "gpt-3.5-turbo"
+
+    # OpenAI-compatible endpoint overrides (for LLM cleaner)
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    default_headers: Optional[Dict[str, str]] = None
 
     # Finetuned cleaner settings
     finetuned: FinetunedCleanerConfig = Field(default_factory=FinetunedCleanerConfig)

--- a/src/pyagentshield/core/shield.py
+++ b/src/pyagentshield/core/shield.py
@@ -134,6 +134,10 @@ class AgentShield:
 
             return OpenAIEmbeddingProvider(
                 model_name=self.config.embeddings.openai_model,
+                api_key=self.config.embeddings.api_key,
+                cache_embeddings=self.config.performance.cache_embeddings,
+                base_url=self.config.embeddings.base_url,
+                default_headers=self.config.embeddings.default_headers,
             )
         elif self.config.embeddings.provider == "mlx":
             from pyagentshield.providers.mlx import MLXEmbeddingProvider
@@ -157,7 +161,12 @@ class AgentShield:
 
         elif method == "llm":
             from pyagentshield.cleaning.llm import LLMCleaner
-            return LLMCleaner(model=self.config.cleaning.llm_model)
+            return LLMCleaner(
+                model=self.config.cleaning.llm_model,
+                api_key=self.config.cleaning.api_key,
+                base_url=self.config.cleaning.base_url,
+                default_headers=self.config.cleaning.default_headers,
+            )
 
         elif method == "finetuned":
             from pyagentshield.cleaning.finetuned import FinetunedCleaner
@@ -199,6 +208,9 @@ class AgentShield:
                 temperature=ft_config.temperature,
                 # Pass LLM config for any LLM cleaners in hybrid
                 llm_model=self.config.cleaning.llm_model,
+                api_key=self.config.cleaning.api_key,
+                base_url=self.config.cleaning.base_url,
+                default_headers=self.config.cleaning.default_headers,
             )
 
         else:

--- a/src/pyagentshield/providers/openai.py
+++ b/src/pyagentshield/providers/openai.py
@@ -41,6 +41,8 @@ class OpenAIEmbeddingProvider:
         model_name: str = "text-embedding-3-small",
         api_key: Optional[str] = None,
         cache_embeddings: bool = True,
+        base_url: Optional[str] = None,
+        default_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initialize the OpenAI embedding provider.
@@ -49,10 +51,16 @@ class OpenAIEmbeddingProvider:
             model_name: OpenAI embedding model name
             api_key: OpenAI API key (uses OPENAI_API_KEY env var if not provided)
             cache_embeddings: Whether to cache embeddings in memory
+            base_url: Custom API base URL for OpenAI-compatible endpoints
+                (e.g. OpenRouter, Together, Ollama, vLLM)
+            default_headers: Extra HTTP headers sent with every request
         """
         self._model_name = model_name
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self._cache_embeddings = cache_embeddings
+        self._base_url = base_url
+        self._default_headers = default_headers
+        self._provider_type = "openai"
 
         if not self._api_key:
             raise EmbeddingError(
@@ -86,7 +94,12 @@ class OpenAIEmbeddingProvider:
                     "Install with: pip install pyagentshield[openai]"
                 ) from e
 
-            self._client = OpenAI(api_key=self._api_key)
+            kwargs: Dict[str, Any] = {"api_key": self._api_key}
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            if self._default_headers:
+                kwargs["default_headers"] = self._default_headers
+            self._client = OpenAI(**kwargs)
 
         return self._client
 

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,0 +1,100 @@
+"""Tests for OpenAI-compatible adapter (base_url/default_headers)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pyagentshield.core.config import ShieldConfig
+
+
+class TestOpenAIProviderBaseUrl:
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_client_receives_base_url_and_headers(self):
+        from pyagentshield.providers.openai import OpenAIEmbeddingProvider
+
+        provider = OpenAIEmbeddingProvider(
+            model_name="text-embedding-3-small",
+            base_url="https://openrouter.ai/api/v1",
+            default_headers={"HTTP-Referer": "https://example.com"},
+        )
+
+        with patch.dict("sys.modules", {"openai": MagicMock()}):
+            import sys
+
+            mock_openai = sys.modules["openai"].OpenAI
+            provider._client = None
+            provider._get_client()
+            mock_openai.assert_called_once_with(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                default_headers={"HTTP-Referer": "https://example.com"},
+            )
+
+
+class TestLLMCleanerBaseUrl:
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_client_receives_base_url_and_headers(self):
+        from pyagentshield.cleaning.llm import LLMCleaner
+
+        cleaner = LLMCleaner(
+            model="gpt-4o-mini",
+            base_url="https://openrouter.ai/api/v1",
+            default_headers={"HTTP-Referer": "https://example.com"},
+        )
+
+        with patch.dict("sys.modules", {"openai": MagicMock()}):
+            import sys
+
+            mock_openai = sys.modules["openai"].OpenAI
+            cleaner._client = None
+            cleaner._get_client()
+            mock_openai.assert_called_once_with(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                default_headers={"HTTP-Referer": "https://example.com"},
+            )
+
+
+class TestConfigAndWiring:
+    def test_config_parses_openai_compatible_fields(self):
+        config = ShieldConfig.from_dict({
+            "embeddings": {
+                "provider": "openai",
+                "api_key": "emb-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "default_headers": {"X-Test": "1"},
+            },
+            "cleaning": {
+                "method": "llm",
+                "api_key": "clean-key",
+                "base_url": "https://together.xyz/v1",
+                "default_headers": {"X-Test": "2"},
+            },
+        })
+        assert config.embeddings.base_url == "https://openrouter.ai/api/v1"
+        assert config.cleaning.base_url == "https://together.xyz/v1"
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"})
+    def test_hybrid_llm_receives_openai_compatible_fields(self):
+        from pyagentshield.cleaning.hybrid import create_hybrid_cleaner
+
+        cleaner = create_hybrid_cleaner(
+            methods=["heuristic", "llm"],
+            mode="sequential",
+            llm_model="gpt-4o-mini",
+            base_url="https://openrouter.ai/api/v1",
+            default_headers={"HTTP-Referer": "https://example.com"},
+        )
+        llm = next(c for c in cleaner.cleaners if c.method == "llm")
+        assert llm._base_url == "https://openrouter.ai/api/v1"
+        assert llm._default_headers == {"HTTP-Referer": "https://example.com"}
+
+    def test_shield_passes_cache_embeddings_to_openai_provider(self):
+        from pyagentshield.core.shield import AgentShield
+
+        shield = AgentShield(config={
+            "embeddings": {"provider": "openai", "api_key": "test-key"},
+            "performance": {"cache_embeddings": False},
+            "telemetry": {"enabled": False},
+        })
+        assert shield.embedding_provider._cache_embeddings is False


### PR DESCRIPTION
## Summary
Add OpenAI-compatible endpoint support for both embedding and LLM-cleaning paths, including config surface and runtime wiring.

Closes #6.

## Problem
Provider support was effectively constrained to OpenAI defaults. Although code used OpenAI SDKs, there was no complete config+wiring path for OpenAI-compatible backends (OpenRouter, Together, Ollama/vLLM gateways) across both:
- embedding provider
- LLM cleaner (including nested hybrid cleaner paths)

This limited practical multi-model/backend adoption.

## What changed
### 1) Config surface for OpenAI-compatible endpoints
- Added config fields for embeddings and cleaning:
  - `api_key`
  - `base_url`
  - `default_headers`
- Files:
  - `src/pyagentshield/core/config.py`

### 2) Embedding provider transport support
- `OpenAIEmbeddingProvider` now accepts and forwards:
  - `base_url`
  - `default_headers`
- Also tracks provider type metadata used by downstream identity logic.
- File:
  - `src/pyagentshield/providers/openai.py`

### 3) LLM cleaner transport support
- `LLMCleaner` now accepts and forwards:
  - `base_url`
  - `default_headers`
- File:
  - `src/pyagentshield/cleaning/llm.py`

### 4) Runtime wiring in AgentShield
- `AgentShield` now passes configured OpenAI-compatible fields into:
  - OpenAI embedding provider
  - LLMCleaner
  - hybrid cleaner nested LLM path
- Ensures `cache_embeddings` from performance config reaches OpenAI provider.
- Files:
  - `src/pyagentshield/core/shield.py`
  - `src/pyagentshield/cleaning/hybrid.py`

## Why this matters
This unlocks immediate multi-backend support with minimal surface area change by using OpenAI-compatible API contracts, without requiring a custom provider class for each vendor.

## Validation
- Added focused compatibility tests in `tests/test_openai_compat.py`.
- Ran:
  - `PYTHONPATH=src python3 -m pytest -q tests/test_openai_compat.py tests/test_hybrid_cleaner.py tests/test_config.py`
- Result: passing.

## Changed files
- `src/pyagentshield/core/config.py`
- `src/pyagentshield/providers/openai.py`
- `src/pyagentshield/cleaning/llm.py`
- `src/pyagentshield/cleaning/hybrid.py`
- `src/pyagentshield/core/shield.py`
- `tests/test_openai_compat.py`