### PR TITLE
Capability Discovery

### DIFF
--- a/src/pyagentshield/core/config.py
+++ b/src/pyagentshield/core/config.py
@@ -24,6 +24,7 @@ class EmbeddingConfig(BaseModel):
     api_key: Optional[str] = None
     base_url: Optional[str] = None
     default_headers: Optional[Dict[str, str]] = None
+    dimensions: Optional[int] = None
 
     # MLX-specific settings (Apple Silicon)
     mlx_cache_dir: Optional[str] = None  # Cache for converted MLX models

--- a/src/pyagentshield/core/shield.py
+++ b/src/pyagentshield/core/shield.py
@@ -138,6 +138,8 @@ class AgentShield:
                 cache_embeddings=self.config.performance.cache_embeddings,
                 base_url=self.config.embeddings.base_url,
                 default_headers=self.config.embeddings.default_headers,
+                dimensions=self.config.embeddings.dimensions,
+                cache_dir=get_cache_dir(self.config),
             )
         elif self.config.embeddings.provider == "mlx":
             from pyagentshield.providers.mlx import MLXEmbeddingProvider


### PR DESCRIPTION
## Summary
Add capability discovery for embedding dimensions in the OpenAI-compatible embedding provider, including discovery, persistence, and batch safety.

Closes #7.

## Problem
Dimension handling for unknown embedding models relied on static assumptions and could fail or drift in OpenAI-compatible environments where model dimensions vary. This risks:
- incorrect fallback dimensions
- batch edge-case failures (mixed empty + non-empty inputs)
- repeated rediscovery overhead
- cache collisions if endpoint identity is ambiguous

## What changed
### 1) Dimension resolution strategy in OpenAI embedding provider
Implemented robust order:
1. explicit config (`embeddings.dimensions`)
2. static known-model map
3. disk cache lookup
4. provisional fallback (until first real embedding response)

### 2) Runtime discovery + persistence
- On first real embedding response, provider confirms dimensions thread-safely.
- Discovered dimensions are persisted to disk cache (`dimensions_cache.json`) and reused across instances.
- Cache key includes provider/model/host identity, with host extraction that preserves non-default ports.

### 3) Batch-path safety
- `encode_batch()` now safely handles mixed empty/non-empty inputs for unknown models.
- Empty rows are filled after confirmed dimensions are known.
- Prevents shape mismatch crashes from provisional-vs-actual dimension transitions.

### 4) Config and wiring
- Added `embeddings.dimensions` to config.
- `AgentShield` now passes:
  - `dimensions`
  - cache directory (`get_cache_dir(config)`) into OpenAI provider.

## Why this matters
This enables reliable capability discovery for arbitrary OpenAI-compatible embedding endpoints and removes hidden fragility in unknown-model and mixed-batch scenarios.

## Validation
Ran:
- `PYTHONPATH=src python3 -m pytest -q tests/test_openai_compat.py tests/test_config.py`

Result: passing.

## Changed files
- `src/pyagentshield/providers/openai.py`
- `src/pyagentshield/core/config.py`
- `src/pyagentshield/core/shield.py`
- `tests/test_openai_compat.py`